### PR TITLE
switch from File::Slurp to Path::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Pod::Github
 
+        Switch from File::Slurp to Path::Tiny
+
 0.03    13 Nov 2017
         Added EXE_FILES to Makefile.PL; update README
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Carp' => '0',
         'Encode' => '0',
-        'File::Slurp' => '0',
+        'Path::Tiny' => '0',
         'Getopt::Long' => '0',
         'parent' => '0',
         'Pod::Markdown' => '3.005',

--- a/lib/Pod/Github.pm
+++ b/lib/Pod/Github.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp qw(croak);
 use Encode;
-use File::Slurp qw(read_file);
+use Path::Tiny;
 use parent 'Pod::Markdown';
 
 our $VERSION = '0.03';
@@ -49,7 +49,7 @@ sub _include_markdown {
     my $conf = $self->{$DATA_KEY};
 
     my $content = $conf->{$name}           ? $conf->{$name}
-                : $conf->{$name . '-file'} ? scalar read_file($conf->{$name . '-file'})
+                : $conf->{$name . '-file'} ? path($conf->{$name . '-file'})->slurp_utf8
                                            : undef
                                            ;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,7 +2,7 @@ use Test::More tests => 2;
 use strict;
 use warnings;
 use Pod::Github;
-use File::Slurp qw(read_file);
+use Path::Tiny;
 use FindBin qw($Bin);
 
 my %default_args = (
@@ -22,7 +22,7 @@ sub test {
 
     $args = { %default_args,  %$args };
 
-    my $expected = read_file("$Bin/../t/fixtures/$outfile");
+    my $expected = path("$Bin/../t/fixtures/$outfile")->slurp_utf8;
 
     my $obj = Pod::Github->new(%$args);
     $obj->output_string(\my $actual);


### PR DESCRIPTION
File::Slurp has a number of issues with utf8 encoding, and generates warnings on 5.26 (soon to be fatal on 5.30) (see https://rt.cpan.org/Dist/Display.html?Name=File-Slurp) -- Path::Tiny is a well-maintained and robust replacement that handles encodings properly.  This was a simple drop-in replacement.

Thanks for this module; we are using it to keep our project documentation up to date!